### PR TITLE
fix: support additional legacy file name Podfile.rb

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,6 +22,7 @@ const MANIFEST_FILE_NAMES = [
   "CocoaPods.podfile.yaml",
   "CocoaPods.podfile",
   "Podfile",
+  "Podfile.rb",
 ];
 
 const LOCKFILE_NAME = "Podfile.lock";


### PR DESCRIPTION
- [x] ~~Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)~~
- [x] ~~Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)~~
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds support for `Podfile.rb` as possible manifest file name.

### More information

- See https://github.com/CocoaPods/CocoaPods/issues/8171