### PR TITLE
fix: catch lockfile parse errors

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -166,7 +166,12 @@ async function verifyChecksum(manifestFilePath: string, lockfilePath: string): P
 }
 
 async function getAllDeps(lockfilePath: string): Promise<DepTree> {
-  const parser = await LockfileParser.readFile(lockfilePath);
+  let parser: LockfileParser;
+  try {
+    parser = await LockfileParser.readFile(lockfilePath);
+  } catch (error) {
+    throw new Error(`Error while parsing ${LOCKFILE_NAME}:\n${error.message}`);
+  }
   const graph = parser.toDepGraph();
   return graphToDepTree(graph, "cocoapods") as DepTree;
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/snyk/snyk-cocoapods-plugin#readme",
   "dependencies": {
     "@snyk/cli-interface": "^1.5.0",
-    "@snyk/cocoapods-lockfile-parser": "^2.0.0",
+    "@snyk/cocoapods-lockfile-parser": "^2.0.2",
     "@snyk/dep-graph": "^1.10.1",
     "source-map-support": "^0.5.7",
     "tslib": "^1.9.3"

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   ],
   "homepage": "https://github.com/snyk/snyk-cocoapods-plugin#readme",
   "dependencies": {
-    "@snyk/cli-interface": "^1.5.0",
-    "@snyk/cocoapods-lockfile-parser": "^2.0.2",
-    "@snyk/dep-graph": "^1.10.1",
+    "@snyk/cli-interface": "1.5.0",
+    "@snyk/cocoapods-lockfile-parser": "2.0.2",
+    "@snyk/dep-graph": "1.13.0",
     "source-map-support": "^0.5.7",
     "tslib": "^1.9.3"
   },

--- a/test/fixtures/lockfile_in_conflict/Podfile.lock
+++ b/test/fixtures/lockfile_in_conflict/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - Reachability (3.1.0)
+
+DEPENDENCIES:
+<<<<<<< HEAD
+  - Reachability (= 3.1.0)
+=======
+  - Reachability (~> 3.0.0)
+>>>>>>> c001bada55d00dc0dedabad1dea011c00ldecaf1
+
+SPEC REPOS:
+  trunk:
+    - Reachability
+
+SPEC CHECKSUMS:
+  Reachability: 3c8fe9643e52184d17f207e781cd84158da8c02b

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -225,6 +225,14 @@ describe('inspect(rootDir, targetFile?, options?)', () => {
     });
   });
 
+  test('fails if the targetFile cannot be parsed', async () => {
+    await expect(
+      inspect(fixtureDir('lockfile_in_conflict')),
+    ).rejects.toThrowError(
+      /^Error while parsing Podfile.lock:\ncan not read a block mapping entry/,
+    );
+  });
+
   describe('with an options.subProject argument', () => {
     test('fails', async () => {
       await expect(


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] ~~Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)~~
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] https://github.com/snyk/cocoapods-lockfile-parser/pull/14 was merged and shipped

### What this does

This catches when a lockfile is invalid and throws a nice error, explaining the user what actually happened, because otherwise the error message will have no context.