### PR TITLE
fix: pick correct manifest / lockfile with multi project

### DIFF
--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -148,6 +148,20 @@ describe('inspect(rootDir, targetFile?, options?)', () => {
       });
     });
 
+    describe('with multi project fixture', () => {
+      test('works when the Podfile is in a subdir', async () => {
+        await expect(
+          inspect(fixtureDir('multi'), 'a/Podfile'),
+        ).resolves.toMatchObject(singlePkgResultMatcher(/^a\/Podfile$/));
+      });
+
+      test('works when the Podfile.lock is in a subdir', async () => {
+        await expect(
+          inspect(fixtureDir('multi'), 'a/Podfile.lock'),
+        ).resolves.toMatchObject(singlePkgResultMatcher(/^a\/Podfile$/));
+      });
+    });
+
     describe('with a fixture where no manifest file is present', () => {
       test('works with the Podfile.lock', async () => {
         await expect(


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] ~~Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)~~
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This ensures that …
* when you call `snyk test --file=a/Podfile`, the `Podfile.lock` in the subdir `a/` will be found,
* when you call `snyk test --file=a/Podfile.lock`, the `Podfile` in the subdir `a/` will be found,

… and reported as `targetFile=a/Podfile`
