### PR TITLE
fix: update lockfile parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/snyk/snyk-cocoapods-plugin#readme",
   "dependencies": {
     "@snyk/cli-interface": "1.5.0",
-    "@snyk/cocoapods-lockfile-parser": "2.0.2",
+    "@snyk/cocoapods-lockfile-parser": "2.0.4",
     "@snyk/dep-graph": "1.13.0",
     "source-map-support": "^0.5.7",
     "tslib": "^1.9.3"


### PR DESCRIPTION
For https://github.com/snyk/cocoapods-lockfile-parser/pull/18 and https://github.com/snyk/cocoapods-lockfile-parser/pull/17.

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Updates the lockfile parser package to adopt two bug fixes.
