### PR TITLE
fix: Change package manager name from `CocoaPods` to `cocoapods`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/snyk/snyk-cocoapods-plugin#readme",
   "dependencies": {
     "@snyk/cli-interface": "1.5.0",
-    "@snyk/cocoapods-lockfile-parser": "2.0.4",
+    "@snyk/cocoapods-lockfile-parser": "3.0.0",
     "@snyk/dep-graph": "1.13.0",
     "source-map-support": "^0.5.7",
     "tslib": "^1.9.3"

--- a/test/lib/__snapshots__/index.test.ts.snap
+++ b/test/lib/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ Object {
     },
     "name": "legacy_manifest_file",
     "packageFormatVersion": "cocoapods:0.0.1",
-    "type": "CocoaPods",
+    "type": "cocoapods",
     "version": "0.0.0",
   },
   "plugin": Object {
@@ -42,7 +42,7 @@ Object {
     },
     "name": "simple_without_manifest",
     "packageFormatVersion": "cocoapods:0.0.1",
-    "type": "CocoaPods",
+    "type": "cocoapods",
     "version": "0.0.0",
   },
   "plugin": Object {
@@ -69,7 +69,7 @@ Object {
     },
     "name": "simple",
     "packageFormatVersion": "cocoapods:0.0.1",
-    "type": "CocoaPods",
+    "type": "cocoapods",
     "version": "0.0.0",
   },
   "plugin": Object {
@@ -96,7 +96,7 @@ Object {
     },
     "name": "simple",
     "packageFormatVersion": "cocoapods:0.0.1",
-    "type": "CocoaPods",
+    "type": "cocoapods",
     "version": "0.0.0",
   },
   "plugin": Object {
@@ -123,7 +123,7 @@ Object {
     },
     "name": "legacy_manifest_file",
     "packageFormatVersion": "cocoapods:0.0.1",
-    "type": "CocoaPods",
+    "type": "cocoapods",
     "version": "0.0.0",
   },
   "plugin": Object {
@@ -150,7 +150,7 @@ Object {
     },
     "name": "simple_without_manifest",
     "packageFormatVersion": "cocoapods:0.0.1",
-    "type": "CocoaPods",
+    "type": "cocoapods",
     "version": "0.0.0",
   },
   "plugin": Object {
@@ -3666,7 +3666,7 @@ Object {
     },
     "name": "eigen",
     "packageFormatVersion": "cocoapods:0.0.1",
-    "type": "CocoaPods",
+    "type": "cocoapods",
     "version": "0.0.0",
   },
   "plugin": Object {
@@ -3693,7 +3693,7 @@ Object {
     },
     "name": "simple",
     "packageFormatVersion": "cocoapods:0.0.1",
-    "type": "CocoaPods",
+    "type": "cocoapods",
     "version": "0.0.0",
   },
   "plugin": Object {


### PR DESCRIPTION
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

BREAKING CHANGE: package manager name changed to `cocoapods`
