### PR TITLE
fix: Unpin `@snyk/dep-graph` version to allow for de-duping

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@snyk/cli-interface": "1.5.0",
     "@snyk/cocoapods-lockfile-parser": "3.0.0",
-    "@snyk/dep-graph": "1.13.0",
+    "@snyk/dep-graph": "^1.13.1",
     "source-map-support": "^0.5.7",
     "tslib": "^1.9.3"
   },


### PR DESCRIPTION
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

- Unpin `@snyk/dep-graph` version to allow for de-duping