### PR TITLE
feat: generate es2015 code for node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@snyk/cocoapods-lockfile-parser": "3.0.0",
     "@snyk/dep-graph": "^1.13.1",
     "source-map-support": "^0.5.7",
-    "tslib": "^1.9.3"
+    "tslib": "^1.10.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",
@@ -53,6 +53,6 @@
     "tsc-watch": "^2.2.1",
     "tslint": "5.11.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.4.1"
+    "typescript": "^3.7.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "es5",
-    "lib": ["es2015", "es2015.promise"],
+    "target": "es2015",
+    "lib": ["es2015"],
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
This removes some uses of tslib's promises from the generated code,
and generally cleans up stack traces and error messages.
