### PR TITLE
feat: bumps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "parserOptions": {
+    "project": "./tsconfig.json",
     "ecmaVersion": 6
   },
   "env": {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -49,7 +49,7 @@ export async function inspect(
   }
 
   let lockfilePath: string;
-  async function expectToFindLockfile(dir: string = '.'): Promise<string> {
+  async function expectToFindLockfile(dir = '.'): Promise<string> {
     const discoveredLockfilePath = await findLockfile(root, dir);
     if (!discoveredLockfilePath) {
       throw new Error("Could not find lockfile \"Podfile.lock\"! This might be resolved by running `pod install`.");
@@ -131,7 +131,7 @@ async function fsReadFile(filename: string): Promise<string> {
   });
 }
 
-async function findManifestFile(root: string, dir: string = '.'): Promise<string | undefined> {
+async function findManifestFile(root: string, dir = '.'): Promise<string | undefined> {
   for (const manifestFileName of MANIFEST_FILE_NAMES) {
     const targetFilePath = path.join(root, dir, manifestFileName);
     if (await fsExists(targetFilePath)) {
@@ -140,7 +140,7 @@ async function findManifestFile(root: string, dir: string = '.'): Promise<string
   }
 }
 
-async function findLockfile(root: string, dir: string = '.'): Promise<string | undefined> {
+async function findLockfile(root: string, dir = '.'): Promise<string | undefined> {
   const lockfilePath = path.join(root, dir, LOCKFILE_NAME);
   if (await fsExists(lockfilePath)) {
     return path.join(dir, LOCKFILE_NAME);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/snyk/snyk-cocoapods-plugin#readme",
   "dependencies": {
     "@snyk/cli-interface": "1.5.0",
-    "@snyk/cocoapods-lockfile-parser": "3.2.0",
+    "@snyk/cocoapods-lockfile-parser": "3.4.0",
     "@snyk/dep-graph": "^1.18.2",
     "source-map-support": "^0.5.7",
     "tslib": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,8 @@
   "scripts": {
     "format:check": "prettier --check '{*,{lib,test}/!(fixtures)/**/*}.{js,ts,json,yml}'",
     "format": "prettier --write '{*,{lib,test}/!(fixtures)/**/*}.{js,ts,json,yml}'",
-    "lint": "npm run format:check && npm run lint:eslint && npm run lint:tslint-config && npm run lint:tslint",
-    "lint:eslint": "eslint --cache '{lib,test}/**/*.ts'",
-    "lint:tslint": "tslint -p tsconfig.json",
-    "lint:tslint-config": "tslint-config-prettier-check ./tslint.json",
+    "lint": "npm run format:check && npm run lint:eslint",
+    "lint:eslint": "eslint 'lib/**/*.ts' && (cd test && eslint '**/*.ts')",
     "test": "npm run lint && npm run test:unit",
     "test:unit": "jest",
     "test:coverage": "npm run test:unit -- --coverage",
@@ -42,17 +40,15 @@
   "devDependencies": {
     "@types/jest": "^24.0.13",
     "@types/node": "^4.0.47",
-    "@typescript-eslint/eslint-plugin": "^1.13.0",
-    "@typescript-eslint/parser": "^1.13.0",
-    "eslint": "^5.16.0",
-    "eslint-config-prettier": "^5.1.0",
+    "@typescript-eslint/eslint-plugin": "^2.33.0",
+    "@typescript-eslint/parser": "^2.33.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.11.0",
     "jest": "^24.8.0",
     "prettier": "^1.18.2",
     "ts-jest": "^24.0.2",
     "ts-node": "7.0.0",
     "tsc-watch": "^2.2.1",
-    "tslint": "5.11.0",
-    "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "jest": "^25.5.4",
-    "prettier": "^1.18.2",
+    "prettier": "^2.0.5",
     "ts-jest": "^25.5.1",
     "ts-node": "^8.10.1",
     "tsc-watch": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -35,20 +35,20 @@
     "@snyk/cocoapods-lockfile-parser": "3.4.0",
     "@snyk/dep-graph": "^1.18.2",
     "source-map-support": "^0.5.7",
-    "tslib": "^1.10.0"
+    "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.13",
-    "@types/node": "^4.0.47",
+    "@types/jest": "^25.2.2",
+    "@types/node": "^8.10.60",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
-    "jest": "^24.8.0",
+    "jest": "^25.5.4",
     "prettier": "^1.18.2",
-    "ts-jest": "^24.0.2",
-    "ts-node": "7.0.0",
+    "ts-jest": "^25.5.1",
+    "ts-node": "^8.10.1",
     "tsc-watch": "^2.2.1",
-    "typescript": "^3.7.3"
+    "typescript": "^3.9.2"
   }
 }

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -12,7 +12,7 @@ const mockedExecute = (execute as unknown) as jest.MockedFunction<
 // The propertyMatchers argument has the compile type `{ then: any, catch: any }`,
 // which is not the runtime type.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function singlePkgResultMatcher(regexp: RegExp = /(^|\/)Podfile$/): any {
+function singlePkgResultMatcher(regexp = /(^|\/)Podfile$/): any {
   return {
     plugin: {
       targetFile: expect.stringMatching(regexp),


### PR DESCRIPTION
### What this does

Upgrade some dev-deps, and pick up the removal of some cruft from `cocoapods-lockfile-parser`, significantly shrinking our production footprint.

The removal of the "trivial" types (`foo: string = 'string'` -> `foo = 'string'`) are from a default rule in new eslint.