### PR TITLE
chore: ignore node diagnostic report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ package-lock.json
 yarn.lock
 .eslintcache
 coverage/
+# Diagnostic reports (https://nodejs.org/api/report.html) 
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Prevents https://nodejs.org/api/report.html of be commited