### PR TITLE
feat: bump parser to update depGraph lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/snyk/snyk-cocoapods-plugin#readme",
   "dependencies": {
     "@snyk/cli-interface": "1.5.0",
-    "@snyk/cocoapods-lockfile-parser": "3.5.0",
+    "@snyk/cocoapods-lockfile-parser": "3.5.1",
     "@snyk/dep-graph": "^1.19.0",
     "source-map-support": "^0.5.7",
     "tslib": "^2.0.0"


### PR DESCRIPTION

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Bumping parser to  @snyk/cocoapods-lockfile-parser@3.5.1
 that uses latest graph lib
### More information

https://github.com/snyk/cocoapods-lockfile-parser/pull/29/files
