### PR TITLE
fix: update deps to upstream

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,4 +1,0 @@
-declare module '@snyk/graphlib' {
-  import type * as graphlib from 'graphlib';
-  export type Graph = graphlib.Graph;
-}

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   ],
   "homepage": "https://github.com/snyk/snyk-cocoapods-plugin#readme",
   "dependencies": {
-    "@snyk/cli-interface": "2.6.1",
-    "@snyk/cocoapods-lockfile-parser": "3.5.1",
-    "@snyk/dep-graph": "^1.19.0",
+    "@snyk/cli-interface": "^2.9.2",
+    "@snyk/cocoapods-lockfile-parser": "3.5.2",
+    "@snyk/dep-graph": "^1.19.4",
     "source-map-support": "^0.5.7",
     "tslib": "^2.0.0"
   },


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [X] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Updates the deps:
- @snyk/cli-interface
- @snyk/cocoapods-lockfile-parser
- @snyk/dep-graph

to use the latest versions which do rely on the upstream (non Snyk-patched) versions of graphlib.

### Notes for the reviewer
Relies on https://github.com/snyk/cocoapods-lockfile-parser/pull/30 being merged first and generating new version `3.5.2`.

### More information
- HAMMER-99
