### PR TITLE
Bump versions of @snyk deps to reduce lodash exposure

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   ],
   "homepage": "https://github.com/snyk/snyk-cocoapods-plugin#readme",
   "dependencies": {
-    "@snyk/cli-interface": "^2.9.2",
-    "@snyk/cocoapods-lockfile-parser": "3.5.2",
-    "@snyk/dep-graph": "^1.19.4",
+    "@snyk/cli-interface": "^2.11.0",
+    "@snyk/cocoapods-lockfile-parser": "3.6.2",
+    "@snyk/dep-graph": "^1.23.1",
     "source-map-support": "^0.5.7",
     "tslib": "^2.0.0"
   },


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [X] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bumps versions of `@snyk` dependencies to reduce lodash expsure. Specifically:
* `@snyk/cocoapods-lockfile-parser` - use latest which uses newer `@snyk/dep-graph` downstream with a lower lodash exposure
* `@snyk/dep-graph` - use latest which uses lodash dot-packages rather than the full lodash
* `@snyk/cli-interface` - bump to latest


### Additional Context

https://snyk.slack.com/archives/C01MDU3UL59
