### PR TITLE
fix: quote args

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,12 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'snyk:lic:npm:shescape:MPL-2.0':
+    - '*':
+        reason: None Given
+        expires: 2022-12-29T09:11:54.820Z
+        created: 2022-11-29T09:11:54.829Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-450202:

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,4 +1,5 @@
 import * as childProcess from 'child_process';
+import { quoteAll } from 'shescape';
 
 export function execute(
   command: string,
@@ -12,6 +13,8 @@ export function execute(
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }
+
+  args = quoteAll(args, spawnOptions);
 
   return new Promise((resolve, reject) => {
     let stdout = '';

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@snyk/cli-interface": "^2.11.0",
     "@snyk/cocoapods-lockfile-parser": "3.6.2",
     "@snyk/dep-graph": "^1.23.1",
+    "shescape": "1.6.1",
     "source-map-support": "^0.5.7",
     "tslib": "^2.0.0"
   },

--- a/test/lib/sub-process.test.ts
+++ b/test/lib/sub-process.test.ts
@@ -27,7 +27,7 @@ describe('execute()', () => {
 
   test('Considers option.cwd', async () => {
     await expect(
-      subProcess.execute('basename', ['$PWD'], { cwd: __dirname }),
+      subProcess.execute('basename $PWD', [], { cwd: __dirname }),
     ).resolves.toEqual('lib\n');
   });
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Escape the content of the args used in `child_processes`.