### PR TITLE
fix: [CLI-104] disabling flagprotection from shescape

### DIFF
--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -4,7 +4,7 @@ import { quoteAll } from 'shescape/stateless';
 export function execute(
   command: string,
   args: string[] = [],
-  options?: { cwd?: string }
+  options?: { cwd?: string },
 ): Promise<string> {
   const spawnOptions: {
     shell: boolean;
@@ -14,7 +14,7 @@ export function execute(
     spawnOptions.cwd = options.cwd;
   }
 
-  args = quoteAll(args, spawnOptions);
+  args = quoteAll(args, { ...spawnOptions, flagProtection: false });
 
   return new Promise((resolve, reject) => {
     let stdout = '';


### PR DESCRIPTION
A small fix coming in after https://github.com/snyk/snyk-cocoapods-plugin/pull/38 was merged. `flagProtection` was [reversed](https://github.com/ericcornelissen/shescape/blob/HEAD/docs/migration.md) in the `v2` of shescape, but it was missed here.

Since no tests failed, it might not be relevant for this. But to avoid some regression, it should be added.