### PR TITLE
fix: added missing release scope

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ workflows:
       - release:
           name: Release
           context:
+            - nodejs-install
             - github-release
           node_version: "24.16.0"
           requires:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

semantic-release needs the `NPM_TOKEN` from the `nodejs-install` scope to check the repo status.